### PR TITLE
Add buildx support to release arm64 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ services:
 
 before_install:
   - sudo apt-get install -y make
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - make test-image deps
 
 install:
@@ -22,12 +26,7 @@ script:
   - make test
 
 after_success:
-  - set -e
-  - if [ -z "${DOCKER_PASS}" ]; then echo "Build triggered by external PR. Skipping docker push" && exit 0; fi
-  - docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}";
   - ./scripts/build.sh
-  - ./test/container.sh
-  - ./scripts/push.sh
 notifications:
   slack:
     secure: tmVjF3xD0nPImvlsnuiU35LZKEFIcZSCR/QJ98x6GBeKTV3SwB2hra8wbHlRh3Dj2dK47YFGSTzzPkp8XrYRpBrqtrPSajwVIoltfmWNg+4WKAZwZK98TLjPcw18Hja1i3iWMCCv2ZpjkhhWSck1Cabh+KX2xBorYNSQDpQ6CokrN2iw/mG1azSG/ioQ4Yp2xhomvNbccLOiaBZed74e+EbJqCIVDnSV2uqmeiDAQp6Ik1/eN8VjT/UjVvVNq6SAiNZ8uNb9oT5A2qR6XMAhN/qDuUpw+ldoM1pH7388nItgaOUhQhxdDJACuj/MaBAEuKDENatOuP2f8H7GMr9L2/sPZLNGL356ZQ8clvRg6/8PlD/JXev0iSYzwXh5yVdT4feg9YoWOULQS9Mzxz/LY0Diu0eSGbK3fUiylpbB0fNqdvi4y3k8WoHHWWPHQASyyNYetlS5PsL0msQweQCpHNDyZ31rBTyzGAoP7hINhG/+pi3EXopjYYOQjcVdFyqjKRURhOMg3GaqT9jEJsD1mj+tpXUYsI6XlCbO82NMDPwIKazb0jJiCTnJ+OTxlGT5MNXrcw1W3cRomO/ZOXPvYLgd2WLCg646DB0QbGC9y0n1EXbDL6vX/nSGaaQE2Q1SUsUuDMM7zs0EQm9RiMl+DTnmQgLsY0geHK6t8a+jvj0=

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,5 +24,12 @@ CODE_DIR=$(cd $SCRIPT_DIR/..; pwd)
 echo $CODE_DIR
 
 REPO=${GROUP}/$(basename front-end);
-
-$DOCKER_CMD build -t ${REPO}:${COMMIT} .
+$DOCKER_CMD run --rm --privileged multiarch/qemu-user-static --reset -p yes
+$DOCKER_CMD --version
+$DOCKER_CMD login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+$DOCKER_CMD buildx create --name frontendbuildkit
+$DOCKER_CMD buildx use frontendbuildkit
+$DOCKER_CMD buildx inspect --bootstrap
+$DOCKER_CMD buildx build -t odidev/frontend:shellscript --platform linux/arm64,linux/amd64 --push .
+$DOCKER_CMD buildx rm frontendbuildkit
+$DOCKER_CMD logout


### PR DESCRIPTION
Hi

**Package Owner: A J Vigneshwar**

**PR change Details:**

**Patch Details:** 
Following file has been modified :
**build.sh :** Added Buildx commands to build and release the Docker Image for Linux/ARM64 .
**.travis.yml :** Removed push.sh and made only build.sh to execute .

**Testing Detail:**
please find my Docker hub image link here : [https://hub.docker.com/repository/docker/odidev/frontend/tags?page=1&ordering=last_updated)](https://hub.docker.com/repository/docker/odidev/frontend/tags?page=1&ordering=last_updated)
Please find my Travis-ci testing jobs here: [https://app.travis-ci.com/github/vigneshwarajpuresoftware/front-end/jobs/528712910](https://app.travis-ci.com/github/vigneshwarajpuresoftware/front-end/jobs/528712910)

**PR Description: Here is my commit message :**
Added Buildx to the build.sh to release Docker Image for Linux/ARM64 .
Signed-off-by: odidev odidev@puresoftware.com

**Reviewer: Pruthvi Teja Reddy**

Thanks
A J Vigneshwar
Signed-off-by: odidev <odidev@puresoftware.com>